### PR TITLE
Feature/track current player

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,17 +58,14 @@ function trackCurrentPlayer() {
     return currentPlayer;
   }
 
+  function switchCurrentPlayer(player) {
+    currentPlayer = player === 1 ? 2 : 1;
+  }
+
   return {
     currentPlayer,
     setCurrentPlayer,
     getCurrentPlayer,
+    switchCurrentPlayer,
   };
 }
-
-var playerOne = createPlayer(1, 'X');
-var playerTwo = createPlayer(2, 'O');
-console.log('playerOne: ', playerOne.player);
-console.log('playerTwo: ', playerTwo.player);
-var currentPlayer = trackCurrentPlayer();
-currentPlayer.setCurrentPlayer(playerTwo.player.num)
-console.log(currentPlayer.getCurrentPlayer());


### PR DESCRIPTION
This feature allows for setting, getting, and switching the current player. On page load, the set functionality will initialize the current player to player 1. The get functionality will be used to get and display the current player when a win condition is found. If no win condition is found when a move is made, the switch functionality will be used to switch the current state of the current player.
Closes #12 