### PR TITLE
Update gameboard with current players token

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,38 +34,43 @@ function createPlayer(num, token) {
   };
 }
 
-function initializeGameboard() {
-  var board = new Array(9);
-
-  function resetBoard() {
-    for (var i = 0; i < board.length; i++) {
-      board[i] = null;
-    }
-    return board;
-  }
-
-  return resetBoard;
-}
+// Track current player
 
 function trackCurrentPlayer() {
-  var currentPlayer;
-
-  function setCurrentPlayer(player) {
-    currentPlayer = player;
-  }
-
-  function getCurrentPlayer() {
-    return currentPlayer;
-  }
-
-  function switchCurrentPlayer(player) {
-    currentPlayer = player === 1 ? 2 : 1;
-  }
-
   return {
     currentPlayer,
-    setCurrentPlayer,
-    getCurrentPlayer,
-    switchCurrentPlayer,
+
+    setCurrentPlayer: function (player) {
+      this.currentPlayer = player;
+    },
+
+    getCurrentPlayer: function () {
+      return this.currentPlayer;
+    },
+
+    switchCurrentPlayer: function (players) {
+      this.currentPlayer =
+        this.currentPlayer === players[0] ? players[1] : players[0];
+    },
+  };
+}
+
+var currentPlayer = trackCurrentPlayer();
+
+function initializeGameboard() {
+  return {
+    board: new Array(9),
+
+    resetBoard: function () {
+      for (var i = 0; i < this.board.length; i++) {
+        this.board[i] = null;
+      }
+    },
+
+    updateBoard: function (move) {
+      if (!this.board[move]) {
+        this.board[move] = currentPlayer.getCurrentPlayer().getPlayerToken();
+      }
+    },
   };
 }


### PR DESCRIPTION
This commit reflects a large change to the codebase. I initially wrote the board update function to check if the move passed in to it was a falsy value (null) and if so, dynamically access the board array based on the array index number passed in as an argument and assign the current player's token. I was unable to update the local board array data model variable inside of the method found within the function.

To accomplish this functionality I refactored the initializeGameboard function to return an object with a local data model variable, with methods to update that variable using the 'this' keyword.

The gameboard is updated using the current player's token but I noticed that when the switchCurrentPlayer function was invoked, the getCurrentPlayer method called in the updateBoard method was no longer being successfully invoked. I was previously tracking the current player simply by the current player's number attributed to it. I created an array that contained both player objects then refactored the switchCurrentPlayer functionality to switch back and forth between those two objects.

Lastly I refactored the trackCurrentPlayer function to return an object with methods as I did for the initializeGameboard function.

Closes #14 