### PR TITLE
feature/initialize game components

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,8 +49,7 @@ function trackCurrentPlayer(player) {
     },
 
     switchCurrentPlayer: function () {
-      this.player =
-        this.player === players[0] ? players[1] : players[0];
+      this.player = this.player === players[0] ? players[1] : players[0];
     },
   };
 }
@@ -103,13 +102,13 @@ function initializeGameboard() {
 
       // compare stringified version of each array to check for a match
       for (var i = 0; i < winConditions.length; i++) {
-          if (
-            JSON.stringify(winConditions[i]) === JSON.stringify(gameboardState)
-          ) {
-            return true;
-          } else {
-            continue;
-          }
+        if (
+          JSON.stringify(winConditions[i]) === JSON.stringify(gameboardState)
+        ) {
+          return true;
+        } else {
+          continue;
+        }
       }
       return false;
     },


### PR DESCRIPTION
The feature initializes the player and the gameboard on window load.

The trackCurrentPlayer function has been slightly modified for better clarity when accessing the current player property.

Previously, accessing the current player was done by calling `currentPlayer.currentPlayer`. Now it can be referenced using `currentPlayer.player` and subsequently calling the player object's methods.

Additionally, the switchCurrentPlayer method no longer calls for an argument to be passed in. Now, it accesses the global players array rather than the players array being passed in as an argument.

Closes #24 