### PR TITLE
Feature/disable gameplay after win

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,7 @@ window.onload = () => {
       }
       if (gameboard.checkForWin() && isValidMove) {
         handleWin();
-      } else if (gameboard.checkForTie() && isValidMove) {
+      } else if (gameboard.checkForTie()) {
         handleTieGame();
       } else {
         currentPlayer.switchCurrentPlayer();


### PR DESCRIPTION
This feature disables the user from selecting an other cell on the gameboard after a winning move has been made.
Closes #42 